### PR TITLE
Customise display of date-based sort values

### DIFF
--- a/app/controllers/api/helpers.php
+++ b/app/controllers/api/helpers.php
@@ -36,6 +36,7 @@ class HelpersController extends Controller {
         switch($index) {
           case 'siblings':
           case 'children':
+          case 'grandChildren':
             $pages = $page->$index();
             break;
           case 'template':

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -35,7 +35,8 @@ function n($page) {
         return str::substr($page->title(), 0, 1);
         break;
       case 'date':
-        return date('Y/m/d', strtotime($page->num()));
+        $date = date_create_from_format($blueprint->pages()->num()->format(), $page->num());
+        return $date->format($blueprint->pages()->num()->displayformat());
         break;
       default:
         return intval($page->num());

--- a/app/lib/blueprint/pages.php
+++ b/app/lib/blueprint/pages.php
@@ -64,6 +64,7 @@ class Pages extends Obj {
     $obj->mode   = 'default';
     $obj->field  = null;
     $obj->format = null;
+	$obj->displayformat = null;    
 
     if(is_array($this->num)) {
       foreach($this->num as $k => $v) $obj->$k = $v;
@@ -75,6 +76,7 @@ class Pages extends Obj {
       case 'date':
         isset($obj->field)  or $obj->field  = 'date';
         isset($obj->format) or $obj->format = 'Ymd';
+        isset($obj->displayformat) or $obj->displayformat = $obj->format;
         break;
     }
 


### PR DESCRIPTION
Allows to customise how dates are shown next to pages, e.g. from `2014/12/01` to `Mon. 1 Dec 14` — or whatever [date()](http://php.net/manual/en/function.date.php) supports. A blueprint would look like this:

```
pages:
   num :
      format: Ymd
      displayformat : D. j M y
      mode: date
      field: created
```

There is a change in behavior! It defaults to `format` instead of d/m/Y in order to allow to sort pages e.g. only by year, with:

```
pages:
   num :
      format: Y
      mode: date
      field: created
```

(which currently wouldn't work)
