### PR TITLE
Adding Pagination on the Pages sidebar on the Panel Dashboard.

### DIFF
--- a/app/widgets/pages/pages.html.php
+++ b/app/widgets/pages/pages.html.php
@@ -1,5 +1,13 @@
+
+<?php $pagination = $pages->pagination();?>
+
 <ul class="nav nav-list sidebar-list">
   <?php foreach($pages as $c): ?>
   <?php echo new Kirby\Panel\Snippet('pages/sidebar/subpage', array('subpage' => $c)) ?>
   <?php endforeach ?>
 </ul>
+
+<?php echo new Kirby\Panel\Snippet('pagination', array(
+    'pagination' => $pagination, 
+    'nextUrl' => $pagination->nextPageURL(),
+    'prevUrl' => $pagination->prevPageURL())) ?>

--- a/app/widgets/pages/pages.php
+++ b/app/widgets/pages/pages.php
@@ -30,7 +30,7 @@ return array(
   'options' => $options,
   'html'  => function() use($site) {
     return tpl::load(__DIR__ . DS . 'pages.html.php', array(
-      'pages' => $site->children()
+      'pages' => $site->children()->paginate(20)
     ));
   }
 );


### PR DESCRIPTION
This is useful when you have a huge number of of pages with a flat url structure. 
It will make the Pages widget faster and more manageable.
