### PR TITLE
Allow site assets as field options source

### DIFF
--- a/app/src/panel/form/fieldoptions.php
+++ b/app/src/panel/form/fieldoptions.php
@@ -241,6 +241,16 @@ class FieldOptions {
       case 'archives':
         $items = $page->{$method}();
         break;
+      case 'siteFiles':
+      case 'siteImages':
+      case 'siteDocuments':
+      case 'siteVideos':
+      case 'siteAudio':
+      case 'siteCode':
+      case 'siteArchives':
+        $method = strtolower(substr($method, 4));
+        $items = site()->{$method}();
+        break;
       default:
         $items = new Collection();
     }


### PR DESCRIPTION
Simple PR which allows site wide assets to be used as field options sources in addition to the existing page-specific sources.
