### PR TITLE
Add panel.page.show hook

### DIFF
--- a/app/src/panel/models/page.php
+++ b/app/src/panel/models/page.php
@@ -310,7 +310,8 @@ class Page extends \Page {
     // run the hook if the number changed
     if($old->num() != $this->num()) {
       // hit the hook
-      kirby()->trigger('panel.page.sort', [$this, $old]);
+      $action = $old->isInvisible() ? 'show' : 'sort';
+      kirby()->trigger('panel.page.' . $action, [$this, $old]);
     }
 
     return $this->num();


### PR DESCRIPTION
Currently Kirby has the `panel.page.hide` and `panel.page.sort` hooks. When an invisible page
has its status set to visible only the `panel.page.sort` hook is triggered. I
suggest triggering the `panel.page.show` hook instead when the previous page status
was invisible.