### PR TITLE
Fix that headlines in custom widgets aren't compressed in default

### DIFF
--- a/app/views/dashboard/index.php
+++ b/app/views/dashboard/index.php
@@ -6,7 +6,7 @@
     <?php if(!$widget) continue; ?>
     <div class="section white dashboard-section" id="<?php echo $id ?>-widget">
 
-      <h2 class="hgroup<?php e(@$widget['title']['compressed'] == true, ' hgroup-compressed') ?> hgroup-single-line cf">
+      <h2 class="hgroup<?php e(@$widget['title']['compressed'] === true, ' hgroup-compressed') ?> hgroup-single-line cf">
         <?php if(is_array($widget['title']) and $title = $widget['title']): ?>
         <span class="hgroup-title">
           <?php if(!empty($title['link'])): ?>


### PR DESCRIPTION
The custom widgets have a compressed headline without additional options.

This Pull Request fix the issue #907. With this fix the custom widgets have a not compressed headline.