### PR TITLE
Hide pages without read permission from pages widget

### DIFF
--- a/app/widgets/pages/pages.php
+++ b/app/widgets/pages/pages.php
@@ -31,7 +31,9 @@ return array(
   'options' => $options,
   'html'  => function() use($site) {
     return tpl::load(__DIR__ . DS . 'pages.html.php', array(
-      'pages' => $site->children()->paginated('sidebar')
+      'pages' => $site->children()->filter(function($page) {
+        return $page->ui()->read();
+      })->paginated('sidebar')
     ));
   }
 );


### PR DESCRIPTION
If a page is excluded from read access via the 'panel.page.read'
permission, it is no longer shown in the pages widget.

A bit of context, I have a role like this, where I only allow the users to CRUD pages with a certain template:

```php
<?php
return [
  'name'        => 'editor',
  'default'     => false,
  'permissions' => [
    '*'            => false,
    'panel.access' => true,
    'panel.widget.pages' => true,
    'panel.page.read' => function() {
      return $this->target()->page()->template() === 'mytemplate';
    },
    'panel.page.update' => function() {
    ...
  ]
];
```

The problem is, all pages, wether they have that template or not show up in the pages widget.

The user does then get a "access denied" when he tries to view/edit a page in the panel he has no read permission for. I would argue that he should not even see that page in the pages widget if he has no read permission.

I just sketched some code together which seems to do the right thing for me. No idea if this is really the right place for that. Comments welcome! Thanks!